### PR TITLE
sunfish: Remove vendor RenderScript implementation.

### DIFF
--- a/BoardConfig-common.mk
+++ b/BoardConfig-common.mk
@@ -142,9 +142,6 @@ TARGET_USES_HARDWARE_QCOM_GPS := false
 BOARD_VENDOR_QCOM_GPS_LOC_API_HARDWARE := default
 BOARD_VENDOR_QCOM_LOC_PDK_FEATURE_SET := true
 
-# RenderScript
-OVERRIDE_RS_DRIVER := libRSDriver_adreno.so
-
 # Sensors
 TARGET_SUPPORT_DIRECT_REPORT := true
 # Enable sensor Version V_2

--- a/device.mk
+++ b/device.mk
@@ -318,10 +318,6 @@ PRODUCT_PACKAGES += \
     android.hardware.graphics.mapper@4.0-impl-qti-display \
     vendor.qti.hardware.display.allocator-service
 
-# RenderScript HAL
-PRODUCT_PACKAGES += \
-    android.hardware.renderscript@1.0-impl
-
 # Light HAL
 PRODUCT_PACKAGES += \
     lights.sm6150 \


### PR DESCRIPTION
 * RenderScript is deprecated on newer platforms and is being officially replaced.

 * On April 19, 2021, Google announced that RenderScript will be deprecated in Android 12, and recommended porting existing code to Vulkan.

   https://android-developers.googleblog.com/2021/04/android-gpu-compute-going-forward.html

Change-Id: I19460ef266a646b046f1e7d2f0b4eab7c48ae536